### PR TITLE
Remove extraneous print when closing a Dataspace

### DIFF
--- a/h5t.go
+++ b/h5t.go
@@ -124,7 +124,6 @@ func (t *Datatype) finalizer() {
 // Releases a datatype.
 func (t *Datatype) Close() error {
 	if t.id > 0 {
-		fmt.Printf("--- closing dtype [%d]...\n", t.id)
 		err := h5err(C.H5Tclose(t.id))
 		t.id = 0
 		return err


### PR DESCRIPTION
This was probably left after some debugging.
