### PR TITLE
Fix string attributes broken by new cgo rules

### DIFF
--- a/h5a.go
+++ b/h5a.go
@@ -108,15 +108,16 @@ func (s *Attribute) Read(data interface{}, dtype *Datatype) error {
 // Write writes raw data from a buffer to an attribute.
 func (s *Attribute) Write(data interface{}, dtype *Datatype) error {
 	var addr unsafe.Pointer
-	v := reflect.ValueOf(data)
+	v := reflect.Indirect(reflect.ValueOf(data))
 	switch v.Kind() {
 
 	case reflect.Array:
 		addr = unsafe.Pointer(v.UnsafeAddr())
 
 	case reflect.String:
-		str := (*reflect.StringHeader)(unsafe.Pointer(v.UnsafeAddr()))
-		addr = unsafe.Pointer(str.Data)
+		str := C.CString(v.Interface().(string))
+		defer C.free(unsafe.Pointer(str))
+		addr = unsafe.Pointer(&str)
 
 	case reflect.Ptr:
 		addr = unsafe.Pointer(v.Pointer())

--- a/h5a_test.go
+++ b/h5a_test.go
@@ -1,0 +1,64 @@
+package hdf5
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestWriteAttribute(t *testing.T) {
+	DisplayErrors(true)
+	defer DisplayErrors(false)
+	defer os.Remove(fname)
+
+	f, err := CreateFile(fname, F_ACC_TRUNC)
+	if err != nil {
+		t.Fatalf("CreateFile failed: %s\n", err)
+	}
+	defer f.Close()
+
+	scalar, err := CreateDataspace(S_SCALAR)
+	if err != nil {
+		t.Fatalf("CreateDataspace failed: %s\n", err)
+	}
+	defer scalar.Close()
+
+	dset, err := f.CreateDataset("dset", T_NATIVE_USHORT, scalar)
+	if err != nil {
+		t.Fatalf("CreateDataset failed: %s\n", err)
+	}
+	defer dset.Close()
+
+	strVal := "I am a string attribute"
+	intVal := 42
+	fltVal := 1.234
+	arrVal := [3]byte{128, 0, 255}
+
+	attrs := map[string]struct {
+		Value interface{}
+		Type  reflect.Type
+	}{
+		"My string attribute": {&strVal, reflect.TypeOf(strVal)},
+		"My int attribute":    {&intVal, reflect.TypeOf(intVal)},
+		"My float attribute":  {&fltVal, reflect.TypeOf(fltVal)},
+		"My array attribute":  {&arrVal, reflect.TypeOf(arrVal)},
+	}
+
+	for name, v := range attrs {
+		dtype, err := NewDataTypeFromType(v.Type)
+		if err != nil {
+			t.Fatalf("NewDatatypeFromValue failed: %s\n", err)
+		}
+		defer dtype.Close()
+
+		attr, err := dset.CreateAttribute(name, dtype, scalar)
+		if err != nil {
+			t.Fatalf("CreateAttribute failed: %s\n", err)
+		}
+		defer attr.Close()
+
+		if err := attr.Write(v.Value, dtype); err != nil {
+			t.Fatalf("Attribute write failed: %s\n", err)
+		}
+	}
+}


### PR DESCRIPTION
Strings are unique as they are the only datatype whose concrete type is a
pointer (`char*`). This becomes a problem in Go 1.6 when trying to feed
`H5Awrite` a pointer to the backing array of the original string as it becomes
a pointer to a Go pointer and this [provokes a panic][1].

This commit fixes the problem at the expense of copying the strings. Hopefully
this is not as big a problem for attributes since they tend to be small
compared to datasets.

[1]: https://golang.org/doc/go1.6#cgo