### PR TITLE
Problem compiling on debian with go 1.11

### DIFF
--- a/h5t_shim.go
+++ b/h5t_shim.go
@@ -256,7 +256,7 @@ var (
 )
 
 //
-var h5t_VARIABLE uint64 = C.H5T_VARIABLE
+var h5t_VARIABLE uint64 = uint(C.H5T_VARIABLE)
 
 func makeGoStringDatatype() *Datatype {
 	dt, err := T_C_S1.Copy()

--- a/h5t_shim.go
+++ b/h5t_shim.go
@@ -256,7 +256,7 @@ var (
 )
 
 //
-var h5t_VARIABLE uint64 = uint(C.H5T_VARIABLE)
+var h5t_VARIABLE uint64 = uint64(C.H5T_VARIABLE)
 
 func makeGoStringDatatype() *Datatype {
 	dt, err := T_C_S1.Copy()

--- a/h5t_shim.go
+++ b/h5t_shim.go
@@ -256,7 +256,7 @@ var (
 )
 
 //
-var h5t_VARIABLE int64 = C.H5T_VARIABLE
+var h5t_VARIABLE uint64 = C.H5T_VARIABLE
 
 func makeGoStringDatatype() *Datatype {
 	dt, err := T_C_S1.Copy()

--- a/h5t_shim.go
+++ b/h5t_shim.go
@@ -255,8 +255,8 @@ var (
 	T_GO_STRING *Datatype = makeGoStringDatatype()
 )
 
-//
-var h5t_VARIABLE uint64 = uint64(C.H5T_VARIABLE)
+// the only version portable way to do this...<1.11 complains if this is uint64 and >=1.11 complains if it's int64
+var h5t_VARIABLE uint64 = ^uint64(0)
 
 func makeGoStringDatatype() *Datatype {
 	dt, err := T_C_S1.Copy()


### PR DESCRIPTION
> /go/pkg/mod/github.com/sbinet/go-hdf5@v0.0.0-20170101193951-f747bbf37277/h5t_shim.go:259:5: constant 18446744073709551615 overflows int64

This is because h5t_VARIABLE is meant to be an unsigned quantity (and is used as such in makeGoStringDatatype()